### PR TITLE
:bug: [back-port 0.6] updated svn to support tags and head.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.21
 
 require (
 	github.com/devfile/alizer v1.6.0
-	github.com/konveyor/tackle2-addon v0.6.0-alpha.1.0.20241010185506-67652f48f2f2
+	github.com/konveyor/tackle2-addon v0.6.0-beta.1.0.20241122173506-cfd01afbf78f
 	github.com/konveyor/tackle2-hub v0.5.0-rc.1.0.20240726125502-8bb3c0911660
 )
 

--- a/go.sum
+++ b/go.sum
@@ -131,8 +131,8 @@ github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+o
 github.com/klauspost/cpuid/v2 v2.0.9/go.mod h1:FInQzS24/EEf25PyTYn52gqo7WaD8xa0213Md/qVLRg=
 github.com/klauspost/cpuid/v2 v2.2.4 h1:acbojRNwl3o09bUq+yDCtZFc1aiwaAAxtcn8YkZXnvk=
 github.com/klauspost/cpuid/v2 v2.2.4/go.mod h1:RVVoqg1df56z8g3pUjL/3lE5UfnlrJX8tyFgg4nqhuY=
-github.com/konveyor/tackle2-addon v0.6.0-alpha.1.0.20241010185506-67652f48f2f2 h1:xmH1Uw9mGajwXOSsyP3D9j+mHO+7/ukZOyqKKTqjFg0=
-github.com/konveyor/tackle2-addon v0.6.0-alpha.1.0.20241010185506-67652f48f2f2/go.mod h1:1cHTnmMGtYzv0GIMiyEMPkJe+hOlzbhxwRal5e7Mog0=
+github.com/konveyor/tackle2-addon v0.6.0-beta.1.0.20241122173506-cfd01afbf78f h1:Y2zGcAQBC7CwJ4N4VAihk8VE+aLgQgMQGrZIG28hjPM=
+github.com/konveyor/tackle2-addon v0.6.0-beta.1.0.20241122173506-cfd01afbf78f/go.mod h1:XW38q7j44hEwROHvBgKnTwxHCPsBb877miKdl4t+Br0=
 github.com/konveyor/tackle2-hub v0.5.0-rc.1.0.20240726125502-8bb3c0911660 h1:joaeY9ndWjNd6rgwyhoa+lgcIRiNwvAcR9LWQvAyN10=
 github.com/konveyor/tackle2-hub v0.5.0-rc.1.0.20240726125502-8bb3c0911660/go.mod h1:5c5A3i/oARdUp1yo+iYJFFvsIlsbsVGBZT7/CQji9YY=
 github.com/kr/pretty v0.2.0/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=


### PR DESCRIPTION
backport #9 