### PR TITLE
:sparkles: use default creds.

### DIFF
--- a/cmd/discovery.go
+++ b/cmd/discovery.go
@@ -116,6 +116,15 @@ func FetchRepository(application *api.Application) (err error) {
 		err = errors.New("application repository not defined")
 		return
 	}
+	var options []any
+	idapi := addon.Application.Identity(application.ID)
+	identity, found, err := idapi.Find("source")
+	if err != nil {
+		return
+	}
+	if found {
+		options = append(options, identity)
+	}
 	SourceDir = path.Join(
 		SourceDir,
 		strings.Split(
@@ -126,7 +135,7 @@ func FetchRepository(application *api.Application) (err error) {
 	rp, err = repository.New(
 		SourceDir,
 		application.Repository,
-		application.Identities)
+		options...)
 	if err != nil {
 		return
 	}

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.21
 
 require (
 	github.com/devfile/alizer v1.6.0
-	github.com/konveyor/tackle2-addon v0.7.0-alpha.2.0.20250416134249-7c0f33d51619
+	github.com/konveyor/tackle2-addon v0.7.2-0.20250710151242-382302a6e48d
 	github.com/konveyor/tackle2-hub v0.7.0-alpha.2.0.20250623131241-e20023a76c4c
 )
 

--- a/go.sum
+++ b/go.sum
@@ -136,8 +136,8 @@ github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+o
 github.com/klauspost/cpuid/v2 v2.0.9/go.mod h1:FInQzS24/EEf25PyTYn52gqo7WaD8xa0213Md/qVLRg=
 github.com/klauspost/cpuid/v2 v2.2.4 h1:acbojRNwl3o09bUq+yDCtZFc1aiwaAAxtcn8YkZXnvk=
 github.com/klauspost/cpuid/v2 v2.2.4/go.mod h1:RVVoqg1df56z8g3pUjL/3lE5UfnlrJX8tyFgg4nqhuY=
-github.com/konveyor/tackle2-addon v0.7.0-alpha.2.0.20250416134249-7c0f33d51619 h1:BI/0DisZHAGuuQ3PUWNYRQM8M15R5P4WrSeMyHo81lU=
-github.com/konveyor/tackle2-addon v0.7.0-alpha.2.0.20250416134249-7c0f33d51619/go.mod h1:Q71YvZ1e7xWH7/CqWOHYWST0Xbq2s3NOrNhDbAsyMPk=
+github.com/konveyor/tackle2-addon v0.7.2-0.20250710151242-382302a6e48d h1:+ui8IV7S5g4Rhbr8Kt7O3su64CsNnNeEexgYgTofHq8=
+github.com/konveyor/tackle2-addon v0.7.2-0.20250710151242-382302a6e48d/go.mod h1:mITXAU1o/8ZdBoGacaTZxXORfFe1q2S74W9RfTHHm7A=
 github.com/konveyor/tackle2-hub v0.7.0-alpha.2.0.20250623131241-e20023a76c4c h1:nwQmkIxRourGXU5vviaF4BjuNVTnOht5eOBY4++00Ls=
 github.com/konveyor/tackle2-hub v0.7.0-alpha.2.0.20250623131241-e20023a76c4c/go.mod h1:RdQChIneyr3sRRg9X9r2f+EYGLVKXVPiFApOSy3Nq0U=
 github.com/kr/pretty v0.2.0/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=


### PR DESCRIPTION
Use default creds.

Note: The repository.Repository no longer finds the appropriate identity.  The addon needs to find the appropriate identity and pass it as an option.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated a module dependency to a newer version.

* **Refactor**
  * Improved how repository options are constructed when fetching repositories, making the process more dynamic. No changes to user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->