### PR TITLE
:ghost: Use packages in ubi9.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,11 +4,6 @@ COPY --chown=1001:0 . .
 RUN make cmd
 
 FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
-RUN echo -e "[centos9]" \
- "\nname = centos9" \
- "\nbaseurl = http://mirror.stream.centos.org/9-stream/AppStream/\$basearch/os/" \
- "\nenabled = 1" \
- "\ngpgcheck = 0" > /etc/yum.repos.d/centos.repo
 RUN microdnf -y install \
  glibc-langpack-en \
  openssh-clients \


### PR DESCRIPTION
Don't remember why we originally pulled these packages from centos but the same version of git and svn in ubi9.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified container build configuration by removing unnecessary repository setup. The build process continues to function identically with no changes to package installation or runtime behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->